### PR TITLE
CMake Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 cmake_policy(SET CMP0074 NEW)
 project(dual-readout)
 
+
+# HSF cmaketools for fastjet etc.
+
+
 IF(NOT TARGET DD4hep::DDCore)
   find_package ( DD4hep REQUIRED )
   include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
@@ -17,6 +21,9 @@ dd4hep_configure_output()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(CMakeTools)
+UseCMakeTools()
 
 set(HEPMC_DIR "$ENV{HEPMC_DIR}")
 set(PYTHIA_DIR "$ENV{PYTHIA_DIR}")

--- a/DRsim/CMakeLists.txt
+++ b/DRsim/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Setup the project
 project(DRsim)
 
+find_package(HepMC3)
+
 #----------------------------------------------------------------------------
 # Find Geant4 package, activating all available UI and Vis drivers by default
 # You can set WITH_GEANT4_UIVIS to OFF via the command line or ccmake/cmake-gui
@@ -25,7 +27,8 @@ include(${Geant4_USE_FILE})
 # NB: headers are included so they will show up in IDEs
 #
 include_directories(
-  ${HEPMC_DIR}/include
+  ${HEPMC3_INCLUDE_DIR}
+  ${HEPMC3_INTERFACES_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${Geant4_INCLUDE_DIR}
 )
@@ -38,8 +41,8 @@ file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
 add_executable(DRsim DRsim.cc ${sources} ${headers})
 target_link_libraries(
   DRsim ${Geant4_LIBRARIES}
-  ${HEPMC_DIR}/lib64/libHepMC3.so
-  ${HEPMC_DIR}/lib64/libHepMC3rootIO.so
+  ${HEPMC3_LIBRARIES}
+  ${HEPMC3_ROOTIO_LIB}
   rootIO
   DetComponents
   ddDRcalo

--- a/Gen/CMakeLists.txt
+++ b/Gen/CMakeLists.txt
@@ -1,5 +1,9 @@
 project(P8ptcgen)
 
+find_package(Pythia8)
+find_package(HepMC3)
+find_package(FastJet)
+
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${PYTHIA_DIR}/include
@@ -16,10 +20,9 @@ file(GLOB headers
 add_executable(P8ptcgen P8ptcgen.cc ${sources} ${headers})
 target_link_libraries(
   P8ptcgen
-  ${PYTHIA_DIR}/lib/libpythia8.a
-  ${HEPMC_DIR}/lib64/libHepMC3.so
-  ${HEPMC_DIR}/lib64/libHepMC3rootIO.so
-  ${FASTJET_DIR}/lib/libfastjet.so
+  ${PYTHIA8_LIBRARIES}
+  ${HEPMC3_LIBRARIES}
+  ${FASTJET_LIBRARY}
   rootIO
   ${CMAKE_DL_LIBS}
 )
@@ -27,10 +30,9 @@ target_link_libraries(
 add_executable(P8generic P8generic.cc ${sources} ${headers})
 target_link_libraries(
   P8generic
-  ${PYTHIA_DIR}/lib/libpythia8.a
-  ${HEPMC_DIR}/lib64/libHepMC3.so
-  ${HEPMC_DIR}/lib64/libHepMC3rootIO.so
-  ${FASTJET_DIR}/lib/libfastjet.so
+  ${PYTHIA8_LIBRARIES}
+  ${HEPMC3_LIBRARIES}
+  ${FASTJET_LIBRARY}
   rootIO
   ${CMAKE_DL_LIBS}
 )

--- a/Reco/CMakeLists.txt
+++ b/Reco/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(Reco)
 
+find_package(FastJet)
+
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${FASTJET_DIR}/include
@@ -14,7 +16,7 @@ file(GLOB headers
 add_executable(Reco Reco.cc ${sources} ${headers})
 target_link_libraries(
   Reco
-  ${FASTJET_DIR}/lib/libfastjet.so
+  ${FASTJET_LIBRARY}
   rootIO
   ${CMAKE_DL_LIBS}
   DetComponents

--- a/analysis/CMakeLists.txt
+++ b/analysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(analysis)
 
 find_package(ROOT REQUIRED)
+find_package(HepMC3)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -20,8 +21,7 @@ add_executable(analysis analysis.cc ${sources} ${headers})
 #add_executable(calib calib.cc ${sources} ${headers})
 target_link_libraries(
   analysis
-  ${HEPMC_DIR}/lib64/libHepMC3.so
-  ${HEPMC_DIR}/lib64/libHepMC3rootIO.so
+  ${HEPMC3_LIBRARIES}
   rootIO
   ${ROOT_LIBRARIES}
   ${CMAKE_DL_LIBS}

--- a/rootIO/CMakeLists.txt
+++ b/rootIO/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(rootIO)
 
 find_package(ROOT REQUIRED)
+find_package(FastJet)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -19,7 +20,7 @@ add_library(rootIO SHARED ${sources} G__rootIO.cxx)
 target_include_directories(rootIO PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${ROOT_INCLUDE_DIRS})
 target_link_libraries(
   rootIO
-  ${FASTJET_DIR}/lib/libfastjet.so
+  ${FASTJET_LIBRARY}
   ${ROOT_LIBRARIES}
 )
 


### PR DESCRIPTION
With this, I can build the repo with our spack build tool. 

This also helps with maintenance, since it relies less on environment variables set manually before, and uses variables instead of library file names (which can change in unexpected ways, for example lib -> lib64)