### PR TITLE
[ci] update centos7 docker image url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,33 +10,10 @@ jobs:
         SETUP: ['init_lcg.sh', 'init_hsf.sh']
     steps:
     - uses: actions/checkout@v2
-    - name: Install CVMFS
-      run: |
-        wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
-        sudo dpkg -i cvmfs-release-latest_all.deb
-        sudo apt-get update
-        sudo apt-get install cvmfs cvmfs-config-default
-        sudo cvmfs_config setup
-        echo "CVMFS_QUOTA_LIMIT='32140'" > default.local
-        echo "CVMFS_HTTP_PROXY=DIRECT" >> default.local
-        echo "CVMFS_CACHE_BASE='/var/lib/cvmfs'" >> default.local
-        echo "CVMFS_FORCE_SIGNING='yes'" >> default.local
-        echo "CVMFS_FOLLOW_REDIRECTS='yes'" >> default.local
-        echo "CVMFS_REPOSITORIES='sw.hsf.org,sw-nightlies.hsf.org,fcc.cern.ch,sft-nightlies.cern.ch,sft.cern.ch,geant4.cern.ch'" >> default.local
-        echo "CVMFS_SEND_INFO_HEADER=no" >> default.local
-        sudo mkdir -p /etc/cvmfs
-        sudo mv default.local /etc/cvmfs/default.local
-        sudo cvmfs_config probe
-        ls /cvmfs/sft.cern.ch
-        ls /cvmfs/sw.hsf.org
-
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
     - name: Start container
       run: |
-        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg /bin/bash
-    - name: Initialize dependencies
-      run: |
-        docker exec CI_container /bin/bash -c "ln -s /usr/lib64/liblzma.so.5.2.2 /usr/lib64/liblzma.so; cd ./Package;\
-        source ${{ matrix.SETUP }};"
+        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d ghcr.io/aidasoft/centos7:latest /bin/bash
     - name: CMake Configure
       run: |
         docker exec CI_container /bin/bash -c "ln -s /usr/lib64/liblzma.so.5.2.2 /usr/lib64/liblzma.so; cd ./Package;\


### PR DESCRIPTION
Following a change in the TOS, the dockerhub host is no longer available and the image is now hosted on github instead. The symlink to liblzma is now also fixed in the image.
