### PR TITLE
fix clang compile error

### DIFF
--- a/DRreco/src/DRcalib3D.cpp
+++ b/DRreco/src/DRcalib3D.cpp
@@ -93,7 +93,7 @@ StatusCode DRcalib3D::execute() {
     double scale = pSeg->IsCerenkov(cID) ? m_cherenScale.value() : m_scintScale.value();
 
     // create a histogram to do FFT and fill it
-    std::unique_ptr<TH1D> waveHist = std::make_unique<TH1D>("waveHist","waveHist",m_nbins,m_gateStart,m_gateStart+m_gateL);
+    std::unique_ptr<TH1D> waveHist = std::make_unique<TH1D>("waveHist","waveHist",m_nbins,m_gateStart,m_gateStart.operator+(m_gateL));
 
     for (unsigned int bin = 0; bin < waveform.centers_size(); bin++) {
       float timeBin = waveform.getCenters(bin);


### PR DESCRIPTION
clang will break on this routine because of an ambigous operator error
which passes on gcc because gcc incorrectly implements the c++ spec.

see https://stackoverflow.com/questions/25110429/ambiguous-operator-overload-on-clang

Addresses # .

Changes proposed in this pull-request:

-
-

To be done:

- [ ]
- [ ]
