### PR TITLE
Make edm4dr an "extended datamodel"

### DIFF
--- a/edm4dr.yaml
+++ b/edm4dr.yaml
@@ -4,18 +4,6 @@ options:
   exposePODMembers: False
   includeSubfolder: True
 
-components:
-  #------ ObjectID helper struct for references/relations
-  edm4hep::ObjectID: # FIXME already lives in edm4hep, error handling in podio should be improved
-    Members:
-      - int index
-      - int collectionID
-    ExtraCode :
-      includes: "#include <podio/ObjectID.h>\n"
-      declaration: "
-      ObjectID() = default;\n
-      ObjectID(const podio::ObjectID& id ): index(id.index), collectionID(id.collectionID) {}\n
-    "
 
 datatypes :
   edm4hep::SparseVector:

--- a/edm4dr/CMakeLists.txt
+++ b/edm4dr/CMakeLists.txt
@@ -3,9 +3,8 @@
 find_package(EDM4HEP REQUIRED)
 
 # Use the EDM4HEP_DATA_DIR to derive extended data model
-message(STATUS "${EDM4HEP_DATA_DIR}")
 if ("${EDM4HEP_DATA_DIR}" STREQUAL "")
-  message(WARNING "Unable to extend data model since no installed yaml file found.")
+  message(FATAL_ERROR "Unable to extend data model since no installed yaml file found.")
 else()
   message(STATUS "Current EDM4HEP data model is available at ${EDM4HEP_DATA_DIR}.")
 PODIO_GENERATE_DATAMODEL(edm4hep ../edm4dr.yaml headers sources

--- a/edm4dr/CMakeLists.txt
+++ b/edm4dr/CMakeLists.txt
@@ -2,7 +2,16 @@
 # installed podio
 find_package(EDM4HEP REQUIRED)
 
-PODIO_GENERATE_DATAMODEL(edm4hep ../edm4dr.yaml headers sources IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS})
+# Use the EDM4HEP_DATA_DIR to derive extended data model
+message(STATUS "${EDM4HEP_DATA_DIR}")
+if ("${EDM4HEP_DATA_DIR}" STREQUAL "")
+  message(WARNING "Unable to extend data model since no installed yaml file found.")
+else()
+  message(STATUS "Current EDM4HEP data model is available at ${EDM4HEP_DATA_DIR}.")
+PODIO_GENERATE_DATAMODEL(edm4hep ../edm4dr.yaml headers sources
+                        UPSTREAM_EDM edm4hep:${EDM4HEP_DATA_DIR}/edm4hep.yaml
+                        IO_BACKEND_HANDLERS ${PODIO_IO_HANDLERS})
+endif()
 
 # use customized library linking instead of PODIO_ADD_DATAMODEL_CORE_LIB(edm4dr "${headers}" "${sources}")
 


### PR DESCRIPTION
This profits from the recently added functionality in podio (https://github.com/AIDASoft/podio/pull/317) and takes edm4hep::ObjectID from edm4hep proper. This avoids some warning and a possible deadlock in ROOT.
