### PR TITLE
Use enhanced time constants for Scintillation in Geant4

### DIFF
--- a/Detector/DRcalo/compact/DRcalo.xml
+++ b/Detector/DRcalo/compact/DRcalo.xml
@@ -580,9 +580,9 @@
       <composite n="21" ref="H"/>
       <property name="RINDEX" ref="RI_PS"/>
       <property name="ABSLENGTH" ref="AbsLen_PS"/>
-      <property name="FASTCOMPONENT" ref="scintFast_PS"/>
+      <property name="SCINTILLATIONCOMPONENT1" ref="scintFast_PS"/>
       <constant name="SCINTILLATIONYIELD" value="13.9/keV"/>
-      <constant name="FASTTIMECONSTANT" value="2.8*ns"/>
+      <constant name="SCINTILLATIONTIMECONSTANT1" value="2.8*ns"/>
       <constant name="RESOLUTIONSCALE" value="1."/>
     </material>
     <material name="DR_PyrexGlass">

--- a/Detector/DRcalo/compact/DRcalo_IDEA.xml
+++ b/Detector/DRcalo/compact/DRcalo_IDEA.xml
@@ -580,7 +580,7 @@
       <property name="ABSLENGTH" ref="AbsLen_PS"/>
       <property name="SCINTILLATIONCOMPONENT1" ref="scintFast_PS"/>
       <constant name="SCINTILLATIONYIELD" value="13.9/keV"/>
-      <constant name="FASTTIMECONSTANT" value="2.8*ns"/>
+      <constant name="SCINTILLATIONTIMECONSTANT1" value="2.8*ns"/>
       <constant name="RESOLUTIONSCALE" value="1."/>
     </material>
     <material name="DR_PyrexGlass">

--- a/Detector/DRcalo/compact/DRcalo_IDEA.xml
+++ b/Detector/DRcalo/compact/DRcalo_IDEA.xml
@@ -578,7 +578,7 @@
       <composite n="21" ref="H"/>
       <property name="RINDEX" ref="RI_PS"/>
       <property name="ABSLENGTH" ref="AbsLen_PS"/>
-      <property name="SCINTILLATIONTIMECONSTANT1" ref="scintFast_PS"/>
+      <property name="SCINTILLATIONCOMPONENT1" ref="scintFast_PS"/>
       <constant name="SCINTILLATIONYIELD" value="13.9/keV"/>
       <constant name="FASTTIMECONSTANT" value="2.8*ns"/>
       <constant name="RESOLUTIONSCALE" value="1."/>

--- a/Detector/DRcalo/compact/DRcalo_IDEA.xml
+++ b/Detector/DRcalo/compact/DRcalo_IDEA.xml
@@ -578,7 +578,7 @@
       <composite n="21" ref="H"/>
       <property name="RINDEX" ref="RI_PS"/>
       <property name="ABSLENGTH" ref="AbsLen_PS"/>
-      <property name="FASTCOMPONENT" ref="scintFast_PS"/>
+      <property name="SCINTILLATIONTIMECONSTANT1" ref="scintFast_PS"/>
       <constant name="SCINTILLATIONYIELD" value="13.9/keV"/>
       <constant name="FASTTIMECONSTANT" value="2.8*ns"/>
       <constant name="RESOLUTIONSCALE" value="1."/>

--- a/Detector/DRcalo/compact/DRcalo_Wratten9_S13615-1025.xml
+++ b/Detector/DRcalo/compact/DRcalo_Wratten9_S13615-1025.xml
@@ -574,9 +574,9 @@
       <composite n="21" ref="H"/>
       <property name="RINDEX" ref="RI_PS"/>
       <property name="ABSLENGTH" ref="AbsLen_PS"/>
-      <property name="FASTCOMPONENT" ref="scintFast_PS"/>
+      <property name="SCINTILLATIONCOMPONENT1" ref="scintFast_PS"/>
       <constant name="SCINTILLATIONYIELD" value="13.9/keV"/>
-      <constant name="FASTTIMECONSTANT" value="2.8*ns"/>
+      <constant name="SCINTILLATIONTIMECONSTANT1" value="2.8*ns"/>
       <constant name="RESOLUTIONSCALE" value="1."/>
     </material>
     <material name="DR_PyrexGlass">


### PR DESCRIPTION
This was introduced in 10.7 and is required as of 11.0, see https://geant4-userdoc.web.cern.ch/UsersGuides/ForApplicationDeveloper/html/TrackingAndPhysics/physicsProcess.html#enhanced-time-constants-new-in-10-7

Fixes a runtime error in the simulation for me. Seems correct to me, but waiting for @SanghyunKo to check.

