### PR TITLE
Using getDetector() instead of lcdd()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ QMTest/
 InstallArea/
 patches/
 test_results/
+install/
 
 *-slc[56]-*/
 i686-winxp-vc9-dbg/

--- a/DRreco/src/DRcalib2D.cpp
+++ b/DRreco/src/DRcalib2D.cpp
@@ -26,7 +26,7 @@ StatusCode DRcalib2D::initialize() {
     return StatusCode::FAILURE;
   }
 
-  pSeg = dynamic_cast<dd4hep::DDSegmentation::GridDRcalo*>(m_geoSvc->lcdd()->readout(m_readoutName).segmentation().segmentation());
+  pSeg = dynamic_cast<dd4hep::DDSegmentation::GridDRcalo*>(m_geoSvc->getDetector()->readout(m_readoutName).segmentation().segmentation());
 
   readCSV(m_calibPath);
 

--- a/DRreco/src/DRcalib3D.cpp
+++ b/DRreco/src/DRcalib3D.cpp
@@ -30,7 +30,7 @@ StatusCode DRcalib3D::initialize() {
     return StatusCode::FAILURE;
   }
 
-  pSeg = dynamic_cast<dd4hep::DDSegmentation::GridDRcalo*>(m_geoSvc->lcdd()->readout(m_readoutName).segmentation().segmentation());
+  pSeg = dynamic_cast<dd4hep::DDSegmentation::GridDRcalo*>(m_geoSvc->getDetector()->readout(m_readoutName).segmentation().segmentation());
 
   auto veloFile = std::make_unique<TFile>(m_veloFile.value().c_str(),"READ");
   m_veloC.reset( static_cast<TH1D*>(veloFile->Get(m_cherenProf.value().c_str())) );

--- a/DRsim/DRsimG4Components/src/SimG4SaveDRcaloHits.cpp
+++ b/DRsim/DRsimG4Components/src/SimG4SaveDRcaloHits.cpp
@@ -25,8 +25,8 @@ StatusCode SimG4SaveDRcaloHits::initialize() {
     return StatusCode::FAILURE;
   }
 
-  auto lcdd = m_geoSvc->lcdd();
-  auto allReadouts = lcdd->readouts();
+  auto det = m_geoSvc->getDetector();
+  auto allReadouts = det->readouts();
   for (auto& readoutName : m_readoutNames) {
     if (allReadouts.find(readoutName) == allReadouts.end()) {
       error() << "Readout " << readoutName << " not found! Please check tool configuration." << endmsg;

--- a/DRsim/DRsimG4Full/src/components/SimG4DRcaloActions.cpp
+++ b/DRsim/DRsimG4Full/src/components/SimG4DRcaloActions.cpp
@@ -19,7 +19,7 @@ StatusCode SimG4DRcaloActions::initialize() {
     return StatusCode::FAILURE;
   }
 
-  pSeg = dynamic_cast<dd4hep::DDSegmentation::GridDRcalo*>(m_geoSvc->lcdd()->readout(m_readoutName).segmentation().segmentation());
+  pSeg = dynamic_cast<dd4hep::DDSegmentation::GridDRcalo*>(m_geoSvc->getDetector()->readout(m_readoutName).segmentation().segmentation());
 
   return StatusCode::SUCCESS;
 }

--- a/Detector/DRsensitive/src/SDWrapper.cpp
+++ b/Detector/DRsensitive/src/SDWrapper.cpp
@@ -5,9 +5,9 @@
 
 namespace dd4hep {
 namespace sim {
-  static G4VSensitiveDetector* create_DRcaloSiPM_sd(const std::string& aDetectorName, dd4hep::Detector& aLcdd) {
-    std::string readoutName = aLcdd.sensitiveDetector(aDetectorName).readout().name();
-    return new drc::DRcaloSiPMSD(aDetectorName,readoutName,aLcdd.sensitiveDetector(aDetectorName).readout().segmentation());
+  static G4VSensitiveDetector* create_DRcaloSiPM_sd(const std::string& aDetectorName, dd4hep::Detector& aDet) {
+    std::string readoutName = aDet.sensitiveDetector(aDetectorName).readout().name();
+    return new drc::DRcaloSiPMSD(aDetectorName,readoutName,aDet.sensitiveDetector(aDetectorName).readout().segmentation());
   }
 }
 }


### PR DESCRIPTION
Addresses renaming of `lcdd()` member function to `getDetector()`.

Changes proposed in this pull-request:
- Using `getDetector()` instead of `lcdd()`