### PR TITLE
Link to GaudiAlgLib

### DIFF
--- a/DRdigi/CMakeLists.txt
+++ b/DRdigi/CMakeLists.txt
@@ -13,6 +13,7 @@ gaudi_add_module(DRdigi
   LINK
   EDM4HEP::edm4hep
   sipm::sipm
+  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   k4FWCore::k4FWCore
 )

--- a/DRreco/CMakeLists.txt
+++ b/DRreco/CMakeLists.txt
@@ -15,6 +15,7 @@ gaudi_add_module(DRreco
   LINK
   EDM4HEP::edm4hep
   DRsegmentation
+  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   k4FWCore::k4FWCore
   CLHEP::CLHEP

--- a/DRsim/DRsimG4Components/CMakeLists.txt
+++ b/DRsim/DRsimG4Components/CMakeLists.txt
@@ -11,6 +11,7 @@ file(GLOB headers
 gaudi_add_module(DRsimG4Components
   SOURCES ${sources}
   LINK
+  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   k4FWCore::k4FWCore
   EDM4HEP::edm4hep

--- a/DRsim/DRsimG4Fast/CMakeLists.txt
+++ b/DRsim/DRsimG4Fast/CMakeLists.txt
@@ -11,6 +11,7 @@ file(GLOB headers
 gaudi_add_module(DRsimG4Fast
   SOURCES ${sources}
   LINK
+  Gaudi::GaudiAlgLib
   Gaudi::GaudiKernel
   k4FWCore::k4FWCore
   ${Geant4_LIBRARIES}


### PR DESCRIPTION
# Link to GaudiAlgLib

Fix issues when linking like in https://github.com/key4hep/k4RecTracker/pull/20:

```
     231    ERROR: failed to load libDRsimG4Fast.so: /tmp/root/spack-stage/spack-stage-dual-readout-8de91e0a1842acb0c3724374f7be28e8bc5eae5b_develop-5r4qdq5h6s
            4xv2g2wmmsbdyvszmigkvj/spack-build-5r4qdq5/lib/libDRsimG4Fast.so: undefined symbol: _ZTI9GaudiTool
```

