### PR TITLE
Find python3.10 on cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_MODULE_PATH
 include(GNUInstallDirs)
 
 find_package(ROOT REQUIRED)
+find_package(Python 3.10 EXACT)#Find python version according to root
 find_package(podio REQUIRED HINTS $ENV{PODIO})
 find_package(Gaudi REQUIRED)
 find_package(EDM4HEP)


### PR DESCRIPTION
# Find python3.10 on cmake .

Changes proposed in this pull-request:

- Adding `find_package(Python 3.10 EXACT)` to CMakeLists.txt to get corresponding python version with ROOT.
- Without this statement, cmake fails due to another python version on the system.