### PR TITLE
Use .value() for double properties to avoid ambiguous template resolution

### DIFF
--- a/DRdigi/src/DigiSiPM.cpp
+++ b/DRdigi/src/DigiSiPM.cpp
@@ -72,7 +72,7 @@ StatusCode DigiSiPM::execute(const EventContext&) const {
 
     const double integral = anaSignal.integral(m_gateStart,m_gateL,m_thres); // (intStart, intGate, threshold)
     const double toa = anaSignal.toa(m_gateStart,m_gateL,m_thres);           // (intStart, intGate, threshold)
-    const double gateEnd = m_gateStart + m_gateL;
+    const double gateEnd = m_gateStart.value() + m_gateL.value();
 
     digiHit.setEnergy( integral );
     digiHit.setCellID( rawhit.getCellID() );

--- a/DRreco/src/DRcalib3D.cpp
+++ b/DRreco/src/DRcalib3D.cpp
@@ -109,7 +109,7 @@ StatusCode DRcalib3D::execute(const EventContext&) const {
     double scale = pSeg->IsCerenkov(cID) ? m_cherenScale.value() : m_scintScale.value();
 
     // create a histogram to do FFT and fill it
-    std::unique_ptr<TH1D> waveHist = std::make_unique<TH1D>("waveHist","waveHist",m_nbins,m_gateStart,m_gateStart+m_gateL);
+    std::unique_ptr<TH1D> waveHist = std::make_unique<TH1D>("waveHist","waveHist",m_nbins,m_gateStart,m_gateStart.value()+m_gateL.value());
     float sampling = waveform.getInterval();
     float startTime = waveform.getTime();
 


### PR DESCRIPTION
Otherwise GCC 14 complains that there are two possible template candidates for `operator+` and fails to compile. By using `value()` the actual double values are being summed instead of `Gaudi::Property<double>`.