### PR TITLE
Simplify finding DD4hep in CMakeLists.txt to fix builds on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,6 @@ set(CMAKE_MODULE_PATH
 # Use GNU-style hierarchy for installing build products
 include(GNUInstallDirs)
 
-find_package(ROOT REQUIRED)
-find_package(podio REQUIRED HINTS $ENV{PODIO})
-find_package(Gaudi REQUIRED)
-find_package(EDM4HEP)
-find_package(k4FWCore REQUIRED)
-find_package(sipm REQUIRED)
-
 #----------------------------------------------------------------------------
 # Find Geant4 package, activating all available UI and Vis drivers by default
 # You can set WITH_GEANT4_UIVIS to OFF via the command line or ccmake/cmake-gui
@@ -33,6 +26,14 @@ endif()
 find_package ( DD4hep REQUIRED )
 dd4hep_set_compiler_flags()
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
+
+
+find_package(ROOT REQUIRED)
+find_package(podio REQUIRED HINTS $ENV{PODIO})
+find_package(Gaudi REQUIRED)
+find_package(EDM4HEP)
+find_package(k4FWCore REQUIRED)
+find_package(sipm REQUIRED)
 
 set(BOOST_ROOT "$ENV{BOOST_ROOT}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,15 +30,9 @@ else()
   find_package(Geant4 REQUIRED)
 endif()
 
-IF(NOT TARGET DD4hep::DDCore)
-  find_package ( DD4hep REQUIRED )
-  include ( ${DD4hep_DIR}/cmake/DD4hep.cmake )
-  include ( ${DD4hep_DIR}/cmake/DD4hepBuild.cmake )
-  dd4hep_configure_output()
-ENDIF()
-
+find_package ( DD4hep REQUIRED )
 dd4hep_set_compiler_flags()
-dd4hep_configure_output()
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 
 set(BOOST_ROOT "$ENV{BOOST_ROOT}")
 


### PR DESCRIPTION
When building on MacOS, `dd4hep_configure_outputs` seems to have a conflict with Gaudi so that when calling listcomponents` the libraries are not found because of where they are stored in the build directory (set by `dd4hep_configure_outputs`). I am still not sure why this is different on Linux and MacOS, so I fix it here until there is a fix somewhere else. In any case removing the double call of `dd4hep_configure_outputs` should be done anyway. With this fix it is possible to build on MacOS, and I don't see anything different when building on Alma 9.

`EXECUTABLE_OUTPUT_PATH` needs to be set or files will be written to / (coming from an expansion like `${EXECUTABLE_OUTPUT_PATH}/...` which will not always work.

In addition, change the location of `find_package(DD4hep)` to be at the top to make sure that DD4hep finds the correct version of Python before any other package finds an incorrect one.