### PR TITLE
Fix include for when using a more recent version of SimSiPM

### DIFF
--- a/DRdigi/include/DigiSiPM.h
+++ b/DRdigi/include/DigiSiPM.h
@@ -12,7 +12,11 @@
 #include "Gaudi/Algorithm.h"
 #include "GaudiKernel/ToolHandle.h"
 
+#if __has_include("SiPMSensor.h")
 #include "SiPMSensor.h"
+#elif __has_include("sipm/SiPMSensor.h")
+#include "sipm/SiPMSensor.h"
+#endif
 
 class DigiSiPM : public Gaudi::Algorithm {
 public:


### PR DESCRIPTION
Needed after https://github.com/EdoPro98/SimSiPM/commit/55af9ddbbb98d6a717b13b7781c2e46115dcfed6

Note that because of that commit above it's not possible to use a newer version of SimSiPM without patching it because of 
``` 
-target_include_directories(sipm PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+target_include_directories(sipm PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
```
which makes both the headers PRIVATE and it also removes the installation folder, so the headers wouldn't be found even if PUBLIC.