### PR TITLE
Make sure to properly forward declare TH1

### DIFF
--- a/DRreco/include/DRcalib3D.h
+++ b/DRreco/include/DRcalib3D.h
@@ -12,6 +12,7 @@
 #include "GridDRcalo.h"
 #include "k4Interface/IGeoSvc.h"
 
+class TH1;
 class TH1D;
 class IGeoSvc;
 


### PR DESCRIPTION
Make sure to properly forward declare `TH1` as otherwise this requires on some of the included headers to do so. This is very brittle at the moment and upstream changes could easily break builds.