### PR TITLE
Move DataHandle and MetaDataHandle to the k4FWCore namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(ROOT REQUIRED)
 find_package(podio REQUIRED HINTS $ENV{PODIO})
 find_package(Gaudi REQUIRED)
 find_package(EDM4HEP)
-find_package(k4FWCore REQUIRED)
+find_package(k4FWCore 1.3 REQUIRED)
 find_package(sipm REQUIRED)
 
 set(BOOST_ROOT "$ENV{BOOST_ROOT}")

--- a/DRdigi/include/DigiSiPM.h
+++ b/DRdigi/include/DigiSiPM.h
@@ -28,13 +28,15 @@ public:
   StatusCode finalize();
 
 private:
-  mutable DataHandle<edm4hep::RawCalorimeterHitCollection> m_rawHits{"RawCalorimeterHits", Gaudi::DataHandle::Reader,
-                                                                     this};
-  mutable DataHandle<edm4hep::RawTimeSeriesCollection> m_timeStruct{"RawTimeStructs", Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::RawCalorimeterHitCollection> m_rawHits{"RawCalorimeterHits",
+                                                                               Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::RawTimeSeriesCollection> m_timeStruct{"RawTimeStructs",
+                                                                              Gaudi::DataHandle::Reader, this};
 
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{"DigiCalorimeterHits", Gaudi::DataHandle::Writer,
-                                                                   this};
-  mutable DataHandle<edm4hep::TimeSeriesCollection> m_waveforms{"DigiWaveforms", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{"DigiCalorimeterHits",
+                                                                             Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::TimeSeriesCollection> m_waveforms{"DigiWaveforms", Gaudi::DataHandle::Writer,
+                                                                          this};
 
   std::unique_ptr<sipm::SiPMSensor> m_sensor;
 

--- a/DRreco/include/DRcalib2D.h
+++ b/DRreco/include/DRcalib2D.h
@@ -31,9 +31,10 @@ private:
   dd4hep::DDSegmentation::GridDRcalo* pSeg;
   mutable dd4hep::DDSegmentation::DRparamBase* pParamBase;
 
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{"DigiCalorimeterHits", Gaudi::DataHandle::Reader,
-                                                                   this};
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_caloHits{"DRcalo2dHits", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{"DigiCalorimeterHits",
+                                                                             Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_caloHits{"DRcalo2dHits", Gaudi::DataHandle::Writer,
+                                                                             this};
 
   Gaudi::Property<std::string> m_calibPath{this, "calibPath", "share/calib.csv",
                                            "relative path to calibration csv file"};

--- a/DRreco/include/DRcalib3D.h
+++ b/DRreco/include/DRcalib3D.h
@@ -34,12 +34,16 @@ private:
   std::unique_ptr<TH1D> m_veloC;
   std::unique_ptr<TH1D> m_veloS;
 
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{"DigiCalorimeterHits", Gaudi::DataHandle::Reader,
-                                                                   this};
-  mutable DataHandle<edm4hep::TimeSeriesCollection> m_waveforms{"DigiWaveforms", Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_2dHits{"DRcalo2dHits", Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> m_caloHits{"DRcalo3dHits", Gaudi::DataHandle::Writer, this};
-  mutable DataHandle<edm4hep::TimeSeriesCollection> m_postprocTime{"DRpostprocTime", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_digiHits{"DigiCalorimeterHits",
+                                                                             Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::TimeSeriesCollection> m_waveforms{"DigiWaveforms", Gaudi::DataHandle::Reader,
+                                                                          this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_2dHits{"DRcalo2dHits", Gaudi::DataHandle::Reader,
+                                                                           this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> m_caloHits{"DRcalo3dHits", Gaudi::DataHandle::Writer,
+                                                                             this};
+  mutable k4FWCore::DataHandle<edm4hep::TimeSeriesCollection> m_postprocTime{"DRpostprocTime",
+                                                                             Gaudi::DataHandle::Writer, this};
 
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "DRcaloSiPMreadout", "readout name of DRcalo"};
   Gaudi::Property<std::string> m_veloFile{this, "veloFile", "share/velo.root", "velocity profile file name"};

--- a/DRsim/DRsimG4Components/include/SimG4SaveDRcaloHits.h
+++ b/DRsim/DRsimG4Components/include/SimG4SaveDRcaloHits.h
@@ -31,11 +31,12 @@ private:
   Gaudi::Property<std::vector<std::string>> m_readoutNames{
       this, "readoutNames", {"DRcaloSiPMreadout"}, "Name of the readouts (hits collections) to save"};
 
-  mutable DataHandle<edm4hep::RawCalorimeterHitCollection> mRawCaloHits{"RawCalorimeterHits", Gaudi::DataHandle::Writer,
-                                                                        this};
-  mutable DataHandle<edm4hep::RawTimeSeriesCollection> mTimeStruct{"RawTimeStructs", Gaudi::DataHandle::Writer, this};
-  mutable DataHandle<edm4hep::RawTimeSeriesCollection> mWavlenStruct{"RawWavlenStructs", Gaudi::DataHandle::Writer,
-                                                                     this};
+  mutable k4FWCore::DataHandle<edm4hep::RawCalorimeterHitCollection> mRawCaloHits{"RawCalorimeterHits",
+                                                                                  Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::RawTimeSeriesCollection> mTimeStruct{"RawTimeStructs",
+                                                                             Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::RawTimeSeriesCollection> mWavlenStruct{"RawWavlenStructs",
+                                                                               Gaudi::DataHandle::Writer, this};
 };
 
 #endif

--- a/DRsim/DRsimG4Components/include/SimG4SaveDRcaloMCTruth.h
+++ b/DRsim/DRsimG4Components/include/SimG4SaveDRcaloMCTruth.h
@@ -25,11 +25,11 @@ public:
   virtual StatusCode saveOutput(const G4Event& aEvent) final;
 
 private:
-  mutable DataHandle<edm4hep::SimCalorimeterHitCollection> m_Edeps{"SimCalorimeterHits", Gaudi::DataHandle::Writer,
-                                                                   this};
-  mutable DataHandle<edm4hep::SimCalorimeterHitCollection> m_Edeps3d{"Sim3dCalorimeterHits", Gaudi::DataHandle::Writer,
-                                                                     this};
-  mutable DataHandle<edm4hep::MCParticleCollection> m_Leakages{"Leakages", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_Edeps{"SimCalorimeterHits",
+                                                                             Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimCalorimeterHitCollection> m_Edeps3d{"Sim3dCalorimeterHits",
+                                                                               Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_Leakages{"Leakages", Gaudi::DataHandle::Writer, this};
 
   drc::SimG4DRcaloEventAction* m_eventAction;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Move DataHandle and MetaDataHandle to the k4FWCore namespace, done in k4FWCore in https://github.com/key4hep/k4FWCore/pull/317
- Bump the required version of k4FWCore

ENDRELEASENOTES