### PR TITLE
Bump the minimum required version of CMake to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
-cmake_policy(SET CMP0074 NEW)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 project(dual-readout LANGUAGES CXX)
 
 set(CMAKE_MODULE_PATH


### PR DESCRIPTION
Bump the minimum required version of CMake

To 3.12 so that CMP0074 is set to NEW. What I wanted is to remove the following warning:

```
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```